### PR TITLE
Add builder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,14 @@ public void create() {
 
     flexBox = new FlexBox();
     flexBox.setFillParent(true);
-    flexBox.getRoot().setFlexDirection(YogaFlexDirection.ROW);
-    flexBox.getRoot().setWrap(YogaWrap.WRAP);
+    flexBox.getRoot().setFlexDirection(YogaFlexDirection.ROW)
+        .setWrap(YogaWrap.WRAP);
     stage.addActor(flexBox);
         
     Label label = new Label("Item 1", skin);
     label.setAlignment(Align.center);
     YogaNode node = flexBox.add(label);
-    node.setWidth(100);
-    node.setHeight(100);
+    node.setSize(100);
         
     label = new Label("Item 2", skin);
     label.setAlignment(Align.center);

--- a/src/main/java/io/github/orioncraftmc/meditate/YogaNode.java
+++ b/src/main/java/io/github/orioncraftmc/meditate/YogaNode.java
@@ -27,7 +27,7 @@ public abstract class YogaNode implements YogaProps {
 
   public abstract void addChildAt(YogaNode child, int i);
 
-  public abstract void setIsReferenceBaseline(boolean isReferenceBaseline);
+  public abstract YogaNode setIsReferenceBaseline(boolean isReferenceBaseline);
 
   public abstract boolean isReferenceBaseline();
 
@@ -63,131 +63,145 @@ public abstract class YogaNode implements YogaProps {
 
   public abstract YogaDirection getStyleDirection();
 
-  public abstract void setDirection(YogaDirection direction);
+  public abstract YogaNode setDirection(YogaDirection direction);
 
   public abstract YogaFlexDirection getFlexDirection();
 
-  public abstract void setFlexDirection(YogaFlexDirection flexDirection);
+  public abstract YogaNode setFlexDirection(YogaFlexDirection flexDirection);
 
   public abstract YogaJustify getJustifyContent();
 
-  public abstract void setJustifyContent(YogaJustify justifyContent);
+  public abstract YogaNode setJustifyContent(YogaJustify justifyContent);
 
   public abstract YogaAlign getAlignItems();
 
-  public abstract void setAlignItems(YogaAlign alignItems);
+  public abstract YogaNode setAlignItems(YogaAlign alignItems);
 
   public abstract YogaAlign getAlignSelf();
 
-  public abstract void setAlignSelf(YogaAlign alignSelf);
+  public abstract YogaNode setAlignSelf(YogaAlign alignSelf);
 
   public abstract YogaAlign getAlignContent();
 
-  public abstract void setAlignContent(YogaAlign alignContent);
+  public abstract YogaNode setAlignContent(YogaAlign alignContent);
 
   public abstract YogaPositionType getPositionType();
 
-  public abstract void setPositionType(YogaPositionType positionType);
+  public abstract YogaNode setPositionType(YogaPositionType positionType);
 
   public abstract YogaWrap getWrap();
 
-  public abstract void setWrap(YogaWrap flexWrap);
+  public abstract YogaNode setWrap(YogaWrap flexWrap);
 
   public abstract YogaOverflow getOverflow();
 
-  public abstract void setOverflow(YogaOverflow overflow);
+  public abstract YogaNode setOverflow(YogaOverflow overflow);
 
   public abstract YogaDisplay getDisplay();
 
-  public abstract void setDisplay(YogaDisplay display);
+  public abstract YogaNode setDisplay(YogaDisplay display);
 
   public abstract float getFlex();
 
-  public abstract void setFlex(float flex);
+  public abstract YogaNode setFlex(float flex);
 
   public abstract float getFlexGrow();
 
-  public abstract void setFlexGrow(float flexGrow);
+  public abstract YogaNode setFlexGrow(float flexGrow);
 
   public abstract float getFlexShrink();
 
-  public abstract void setFlexShrink(float flexShrink);
+  public abstract YogaNode setFlexShrink(float flexShrink);
 
   public abstract YogaValue getFlexBasis();
 
-  public abstract void setFlexBasis(float flexBasis);
+  public abstract YogaNode setFlexBasis(float flexBasis);
 
-  public abstract void setFlexBasisPercent(float percent);
+  public abstract YogaNode setFlexBasisPercent(float percent);
 
-  public abstract void setFlexBasisAuto();
+  public abstract YogaNode setFlexBasisAuto();
 
   public abstract YogaValue getMargin(YogaEdge edge);
 
-  public abstract void setMargin(YogaEdge edge, float margin);
+  public abstract YogaNode setMargin(YogaEdge edge, float margin);
 
-  public abstract void setMarginPercent(YogaEdge edge, float percent);
+  public abstract YogaNode setMarginPercent(YogaEdge edge, float percent);
 
-  public abstract void setMarginAuto(YogaEdge edge);
+  public abstract YogaNode setMarginAuto(YogaEdge edge);
 
   public abstract YogaValue getPadding(YogaEdge edge);
 
-  public abstract void setPadding(YogaEdge edge, float padding);
+  public abstract YogaNode setPadding(YogaEdge edge, float padding);
 
-  public abstract void setPaddingPercent(YogaEdge edge, float percent);
+  public abstract YogaNode setPaddingPercent(YogaEdge edge, float percent);
 
   public abstract float getBorder(YogaEdge edge);
 
-  public abstract void setBorder(YogaEdge edge, float border);
+  public abstract YogaNode setBorder(YogaEdge edge, float border);
 
   public abstract YogaValue getPosition(YogaEdge edge);
 
-  public abstract void setPosition(YogaEdge edge, float position);
+  public abstract YogaNode setPosition(YogaEdge edge, float position);
 
-  public abstract void setPositionPercent(YogaEdge edge, float percent);
+  public abstract YogaNode setPositionPercent(YogaEdge edge, float percent);
 
   public abstract YogaValue getWidth();
 
-  public abstract void setWidth(float width);
+  public abstract YogaNode setWidth(float width);
 
-  public abstract void setWidthPercent(float percent);
+  public abstract YogaNode setWidthPercent(float percent);
 
-  public abstract void setWidthAuto();
+  public abstract YogaNode setWidthAuto();
 
   public abstract YogaValue getHeight();
 
-  public abstract void setHeight(float height);
+  public abstract YogaNode setHeight(float height);
 
-  public abstract void setHeightPercent(float percent);
+  public abstract YogaNode setHeightPercent(float percent);
 
-  public abstract void setHeightAuto();
+  public abstract YogaNode setHeightAuto();
 
   public abstract YogaValue getMinWidth();
 
-  public abstract void setMinWidth(float minWidth);
+  public abstract YogaNode setMinWidth(float minWidth);
 
-  public abstract void setMinWidthPercent(float percent);
+  public abstract YogaNode setMinWidthPercent(float percent);
 
   public abstract YogaValue getMinHeight();
 
-  public abstract void setMinHeight(float minHeight);
+  public abstract YogaNode setMinHeight(float minHeight);
 
-  public abstract void setMinHeightPercent(float percent);
+  public abstract YogaNode setMinHeightPercent(float percent);
 
   public abstract YogaValue getMaxWidth();
 
-  public abstract void setMaxWidth(float maxWidth);
+  public abstract YogaNode setMaxWidth(float maxWidth);
 
-  public abstract void setMaxWidthPercent(float percent);
+  public abstract YogaNode setMaxWidthPercent(float percent);
 
   public abstract YogaValue getMaxHeight();
 
-  public abstract void setMaxHeight(float maxheight);
+  public abstract YogaNode setMaxHeight(float maxheight);
 
-  public abstract void setMaxHeightPercent(float percent);
+  public abstract YogaNode setMaxHeightPercent(float percent);
 
+  public abstract YogaNode setSize(float size);
+  
+  public abstract YogaNode setSizePercent(float percent);
+  
+  public abstract YogaNode setMinSize(float minSize);
+  
+  public abstract YogaNode setMinSizePercent(float percent);
+  
+  public abstract YogaNode setMaxSize(float minSize);
+  
+  public abstract YogaNode setMaxSizePercent(float percent);
+  
+  public abstract YogaNode setSizeAuto();
+  
   public abstract float getAspectRatio();
 
-  public abstract void setAspectRatio(float aspectRatio);
+  public abstract YogaNode setAspectRatio(float aspectRatio);
 
   public abstract float getLayoutX();
 
@@ -207,13 +221,13 @@ public abstract class YogaNode implements YogaProps {
 
   public abstract void setMeasureFunction(YogaMeasureFunction measureFunction);
 
-  public abstract void setBaselineFunction(YogaBaselineFunction baselineFunction);
+  public abstract YogaNode setBaselineFunction(YogaBaselineFunction baselineFunction);
 
   public abstract boolean isMeasureDefined();
 
   public abstract boolean isBaselineDefined();
 
-  public abstract void setData(Object data);
+  public abstract YogaNode setData(Object data);
 
   
   public abstract Object getData();

--- a/src/main/java/io/github/orioncraftmc/meditate/YogaNodeWrapper.java
+++ b/src/main/java/io/github/orioncraftmc/meditate/YogaNodeWrapper.java
@@ -99,8 +99,9 @@ public class YogaNodeWrapper extends YogaNode {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeInsertChild(mNativePointer, child.mNativePointer, i);
     }
 
-    public void setIsReferenceBaseline(boolean isReferenceBaseline) {
+    public YogaNode setIsReferenceBaseline(boolean isReferenceBaseline) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeSetIsReferenceBaseline(mNativePointer, isReferenceBaseline);
+        return this;
     }
 
     public boolean isReferenceBaseline() {
@@ -260,8 +261,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetDirection(mNativePointer).getValue());
     }
 
-    public void setDirection(YogaDirection direction) {
+    public YogaNode setDirection(YogaDirection direction) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetDirection(mNativePointer, YGDirection.forValue(direction.intValue()));
+        return this;
     }
 
     public YogaFlexDirection getFlexDirection() {
@@ -269,8 +271,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetFlexDirection(mNativePointer).getValue());
     }
 
-    public void setFlexDirection(YogaFlexDirection flexDirection) {
+    public YogaNode setFlexDirection(YogaFlexDirection flexDirection) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexDirection(mNativePointer, YGFlexDirection.forValue(flexDirection.intValue()));
+        return this;
     }
 
     public YogaJustify getJustifyContent() {
@@ -278,8 +281,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetJustifyContent(mNativePointer).getValue());
     }
 
-    public void setJustifyContent(YogaJustify justifyContent) {
+    public YogaNode setJustifyContent(YogaJustify justifyContent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetJustifyContent(mNativePointer, YGJustify.forValue(justifyContent.intValue()));
+        return this;
     }
 
     public YogaAlign getAlignItems() {
@@ -287,8 +291,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetAlignItems(mNativePointer).getValue());
     }
 
-    public void setAlignItems(YogaAlign alignItems) {
+    public YogaNode setAlignItems(YogaAlign alignItems) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetAlignItems(mNativePointer, YGAlign.forValue(alignItems.intValue()));
+        return this;
     }
 
     public YogaAlign getAlignSelf() {
@@ -296,8 +301,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetAlignSelf(mNativePointer).getValue());
     }
 
-    public void setAlignSelf(YogaAlign alignSelf) {
+    public YogaNode setAlignSelf(YogaAlign alignSelf) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetAlignSelf(mNativePointer, YGAlign.forValue(alignSelf.intValue()));
+        return this;
     }
 
     public YogaAlign getAlignContent() {
@@ -305,8 +311,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetAlignContent(mNativePointer).getValue());
     }
 
-    public void setAlignContent(YogaAlign alignContent) {
+    public YogaNode setAlignContent(YogaAlign alignContent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetAlignContent(mNativePointer, YGAlign.forValue(alignContent.intValue()));
+        return this;
     }
 
     public YogaPositionType getPositionType() {
@@ -314,8 +321,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetPositionType(mNativePointer).getValue());
     }
 
-    public void setPositionType(YogaPositionType positionType) {
+    public YogaNode setPositionType(YogaPositionType positionType) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetPositionType(mNativePointer, YGPositionType.forValue(positionType.intValue()));
+        return this;
     }
 
     public YogaWrap getWrap() {
@@ -323,8 +331,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetFlexWrap(mNativePointer).getValue());
     }
 
-    public void setWrap(YogaWrap flexWrap) {
+    public YogaNode setWrap(YogaWrap flexWrap) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexWrap(mNativePointer, YGWrap.forValue(flexWrap.intValue()));
+        return this;
     }
 
     public YogaOverflow getOverflow() {
@@ -332,8 +341,9 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetOverflow(mNativePointer).getValue());
     }
 
-    public void setOverflow(YogaOverflow overflow) {
+    public YogaNode setOverflow(YogaOverflow overflow) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetOverflow(mNativePointer, YGOverflow.forValue(overflow.intValue()));
+        return this;
     }
 
     public YogaDisplay getDisplay() {
@@ -341,48 +351,55 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetDisplay(mNativePointer).getValue());
     }
 
-    public void setDisplay(YogaDisplay display) {
+    public YogaNode setDisplay(YogaDisplay display) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetDisplay(mNativePointer, YGDisplay.forValue(display.intValue()));
+        return this;
     }
 
     public float getFlex() {
         return io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetFlex(mNativePointer);
     }
 
-    public void setFlex(float flex) {
+    public YogaNode setFlex(float flex) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlex(mNativePointer, flex);
+        return this;
     }
 
     public float getFlexGrow() {
         return io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetFlexGrow(mNativePointer);
     }
 
-    public void setFlexGrow(float flexGrow) {
+    public YogaNode setFlexGrow(float flexGrow) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexGrow(mNativePointer, flexGrow);
+        return this;
     }
 
     public float getFlexShrink() {
         return io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetFlexShrink(mNativePointer);
     }
 
-    public void setFlexShrink(float flexShrink) {
+    public YogaNode setFlexShrink(float flexShrink) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexShrink(mNativePointer, flexShrink);
+        return this;
     }
 
     public YogaValue getFlexBasis() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetFlexBasis(mNativePointer));
     }
 
-    public void setFlexBasis(float flexBasis) {
+    public YogaNode setFlexBasis(float flexBasis) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexBasis(mNativePointer, flexBasis);
+        return this;
     }
 
-    public void setFlexBasisPercent(float percent) {
+    public YogaNode setFlexBasisPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexBasisPercent(mNativePointer, percent);
+        return this;
     }
 
-    public void setFlexBasisAuto() {
+    public YogaNode setFlexBasisAuto() {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetFlexBasisAuto(mNativePointer);
+        return this;
     }
 
     public YogaValue getMargin(YogaEdge edge) {
@@ -390,16 +407,19 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetMargin(mNativePointer, YGEdge.forValue(edge.intValue())));
     }
 
-    public void setMargin(YogaEdge edge, float margin) {
+    public YogaNode setMargin(YogaEdge edge, float margin) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMargin(mNativePointer, YGEdge.forValue(edge.intValue()), margin);
+        return this;
     }
 
-    public void setMarginPercent(YogaEdge edge, float percent) {
+    public YogaNode setMarginPercent(YogaEdge edge, float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMarginPercent(mNativePointer, YGEdge.forValue(edge.intValue()), percent);
+        return this;
     }
 
-    public void setMarginAuto(YogaEdge edge) {
+    public YogaNode setMarginAuto(YogaEdge edge) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMarginAuto(mNativePointer, YGEdge.forValue(edge.intValue()));
+        return this;
     }
 
     public YogaValue getPadding(YogaEdge edge) {
@@ -407,20 +427,23 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetPadding(mNativePointer, YGEdge.forValue(edge.intValue())));
     }
 
-    public void setPadding(YogaEdge edge, float padding) {
+    public YogaNode setPadding(YogaEdge edge, float padding) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetPadding(mNativePointer, YGEdge.forValue(edge.intValue()), padding);
+        return this;
     }
 
-    public void setPaddingPercent(YogaEdge edge, float percent) {
+    public YogaNode setPaddingPercent(YogaEdge edge, float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetPaddingPercent(mNativePointer, YGEdge.forValue(edge.intValue()), percent);
+        return this;
     }
 
     public float getBorder(YogaEdge edge) {
         return io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetBorder(mNativePointer, YGEdge.forValue(edge.intValue()));
     }
 
-    public void setBorder(YogaEdge edge, float border) {
+    public YogaNode setBorder(YogaEdge edge, float border) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetBorder(mNativePointer, YGEdge.forValue(edge.intValue()), border);
+        return this;
     }
 
     public YogaValue getPosition(YogaEdge edge) {
@@ -428,100 +451,159 @@ public class YogaNodeWrapper extends YogaNode {
                 io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetPosition(mNativePointer, YGEdge.forValue(edge.intValue())));
     }
 
-    public void setPosition(YogaEdge edge, float position) {
+    public YogaNode setPosition(YogaEdge edge, float position) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetPosition(mNativePointer, YGEdge.forValue(edge.intValue()), position);
+        return this;
     }
 
-    public void setPositionPercent(YogaEdge edge, float percent) {
+    public YogaNode setPositionPercent(YogaEdge edge, float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetPositionPercent(mNativePointer, YGEdge.forValue(edge.intValue()), percent);
+        return this;
     }
 
     public YogaValue getWidth() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetWidth(mNativePointer));
     }
 
-    public void setWidth(float width) {
+    public YogaNode setWidth(float width) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetWidth(mNativePointer, width);
+        return this;
     }
 
-    public void setWidthPercent(float percent) {
+    public YogaNode setWidthPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetWidthPercent(mNativePointer, percent);
+        return this;
     }
 
-    public void setWidthAuto() {
+    public YogaNode setWidthAuto() {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetWidthAuto(mNativePointer);
+        return this;
     }
 
     public YogaValue getHeight() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetHeight(mNativePointer));
     }
 
-    public void setHeight(float height) {
+    public YogaNode setHeight(float height) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetHeight(mNativePointer, height);
+        return this;
     }
 
-    public void setHeightPercent(float percent) {
+    public YogaNode setHeightPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetHeightPercent(mNativePointer, percent);
+        return this;
     }
 
-    public void setHeightAuto() {
+    public YogaNode setHeightAuto() {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetHeightAuto(mNativePointer);
+        return this;
     }
 
     public YogaValue getMinWidth() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetMinWidth(mNativePointer));
     }
 
-    public void setMinWidth(float minWidth) {
+    public YogaNode setMinWidth(float minWidth) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinWidth(mNativePointer, minWidth);
+        return this;
     }
 
-    public void setMinWidthPercent(float percent) {
+    public YogaNode setMinWidthPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinWidthPercent(mNativePointer, percent);
+        return this;
     }
 
     public YogaValue getMinHeight() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetMinHeight(mNativePointer));
     }
 
-    public void setMinHeight(float minHeight) {
+    public YogaNode setMinHeight(float minHeight) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinHeight(mNativePointer, minHeight);
+        return this;
     }
 
-    public void setMinHeightPercent(float percent) {
+    public YogaNode setMinHeightPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinHeightPercent(mNativePointer, percent);
+        return this;
     }
 
     public YogaValue getMaxWidth() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetMaxWidth(mNativePointer));
     }
 
-    public void setMaxWidth(float maxWidth) {
+    public YogaNode setMaxWidth(float maxWidth) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMaxWidth(mNativePointer, maxWidth);
+        return this;
     }
 
-    public void setMaxWidthPercent(float percent) {
+    public YogaNode setMaxWidthPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMaxWidthPercent(mNativePointer, percent);
+        return this;
     }
 
     public YogaValue getMaxHeight() {
         return valueFromNative(io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetMaxHeight(mNativePointer));
     }
 
-    public void setMaxHeight(float maxheight) {
+    public YogaNode setMaxHeight(float maxheight) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMaxHeight(mNativePointer, maxheight);
+        return this;
     }
 
-    public void setMaxHeightPercent(float percent) {
+    public YogaNode setMaxHeightPercent(float percent) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMaxHeightPercent(mNativePointer, percent);
+        return this;
+    }
+    
+    public YogaNode setSize(float size) {
+        setWidth(size);
+        setHeight(size);
+        return this;
+    }
+    
+    public YogaNode setSizePercent(float percent) {
+        setWidthPercent(percent);
+        setHeightPercent(percent);
+        return this;
+    }
+    
+    public YogaNode setMinSize(float minSize) {
+        setMinWidth(minSize);
+        setMinHeight(minSize);
+        return this;
+    }
+    
+    public YogaNode setMinSizePercent(float minSizePercent) {
+        setMinWidthPercent(minSizePercent);
+        setMinHeightPercent(minSizePercent);
+        return this;
+    }
+    
+    public YogaNode setMaxSize(float maxSize) {
+        setMaxWidth(maxSize);
+        setMaxHeight(maxSize);
+        return this;
+    }
+    
+    public YogaNode setMaxSizePercent(float maxSizePercent) {
+        setMaxWidthPercent(maxSizePercent);
+        setMaxHeightPercent(maxSizePercent);
+        return this;
+    }
+    
+    public YogaNode setSizeAuto() {
+        setWidthAuto();
+        setHeightAuto();
+        return this;
     }
 
     public float getAspectRatio() {
         return io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleGetAspectRatio(mNativePointer);
     }
 
-    public void setAspectRatio(float aspectRatio) {
+    public YogaNode setAspectRatio(float aspectRatio) {
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetAspectRatio(mNativePointer, aspectRatio);
+        return this;
     }
 
     public void setMeasureFunction(YogaMeasureFunction measureFunction) {
@@ -548,9 +630,10 @@ public class YogaNodeWrapper extends YogaNode {
                 YogaMeasureMode.fromInt(heightMode));
     }
 
-    public void setBaselineFunction(YogaBaselineFunction baselineFunction) {
+    public YogaNode setBaselineFunction(YogaBaselineFunction baselineFunction) {
         mBaselineFunction = baselineFunction;
         mNativePointer.setBaselineFunc((node, width, height) -> this.baseline(width, height));
+        return this;
     }
 
     public final float baseline(float width, float height) {
@@ -571,8 +654,9 @@ public class YogaNodeWrapper extends YogaNode {
         return mData;
     }
 
-    public void setData(Object data) {
+    public YogaNode setData(Object data) {
         mData = data;
+        return this;
     }
 
     /**

--- a/src/main/java/io/github/orioncraftmc/meditate/interfaces/YogaProps.java
+++ b/src/main/java/io/github/orioncraftmc/meditate/interfaces/YogaProps.java
@@ -7,6 +7,7 @@
 
 package io.github.orioncraftmc.meditate.interfaces;
 
+import io.github.orioncraftmc.meditate.YogaNode;
 import io.github.orioncraftmc.meditate.YogaValue;
 import io.github.orioncraftmc.meditate.enums.*;
 
@@ -14,99 +15,115 @@ public interface YogaProps {
 
   /* Width properties */
 
-  void setWidth(float width);
+  YogaNode setWidth(float width);
 
-  void setWidthPercent(float percent);
+  YogaNode setWidthPercent(float percent);
 
-  void setMinWidth(float minWidth);
+  YogaNode setMinWidth(float minWidth);
 
-  void setMinWidthPercent(float percent);
+  YogaNode setMinWidthPercent(float percent);
 
-  void setMaxWidth(float maxWidth);
+  YogaNode setMaxWidth(float maxWidth);
 
-  void setMaxWidthPercent(float percent);
+  YogaNode setMaxWidthPercent(float percent);
 
-  void setWidthAuto();
+  YogaNode setWidthAuto();
 
   /* Height properties */
 
-  void setHeight(float height);
+  YogaNode setHeight(float height);
 
-  void setHeightPercent(float percent);
+  YogaNode setHeightPercent(float percent);
 
-  void setMinHeight(float minHeight);
+  YogaNode setMinHeight(float minHeight);
 
-  void setMinHeightPercent(float percent);
+  YogaNode setMinHeightPercent(float percent);
 
-  void setMaxHeight(float maxHeight);
+  YogaNode setMaxHeight(float maxHeight);
 
-  void setMaxHeightPercent(float percent);
+  YogaNode setMaxHeightPercent(float percent);
 
-  void setHeightAuto();
+  YogaNode setHeightAuto();
+  
+  /* Size convenience methods */
+  
+  YogaNode setSize(float size);
+  
+  YogaNode setSizePercent(float percent);
+  
+  YogaNode setMinSize(float minSize);
+  
+  YogaNode setMinSizePercent(float percent);
+  
+  YogaNode setMaxSize(float minSize);
+  
+  YogaNode setMaxSizePercent(float percent);
+  
+  YogaNode setSizeAuto();
 
   /* Margin properties */
 
-  void setMargin(YogaEdge edge, float margin);
+  YogaNode setMargin(YogaEdge edge, float margin);
 
-  void setMarginPercent(YogaEdge edge, float percent);
+  YogaNode setMarginPercent(YogaEdge edge, float percent);
 
-  void setMarginAuto(YogaEdge edge);
+  YogaNode setMarginAuto(YogaEdge edge);
 
   /* Padding properties */
 
-  void setPadding(YogaEdge edge, float padding);
+  YogaNode setPadding(YogaEdge edge, float padding);
 
-  void setPaddingPercent(YogaEdge edge, float percent);
+  YogaNode setPaddingPercent(YogaEdge edge, float percent);
 
   /* Position properties */
 
-  void setPositionType(YogaPositionType positionType);
+  YogaNode setPositionType(YogaPositionType positionType);
 
-  void setPosition(YogaEdge edge, float position);
+  YogaNode setPosition(YogaEdge edge, float position);
 
-  void setPositionPercent(YogaEdge edge, float percent);
+  YogaNode setPositionPercent(YogaEdge edge, float percent);
 
   /* Alignment properties */
 
-  void setAlignContent(YogaAlign alignContent);
+  YogaNode setAlignContent(YogaAlign alignContent);
 
-  void setAlignItems(YogaAlign alignItems);
+  YogaNode setAlignItems(YogaAlign alignItems);
 
-  void setAlignSelf(YogaAlign alignSelf);
+  YogaNode setAlignSelf(YogaAlign alignSelf);
 
   /* Flex properties */
 
-  void setFlex(float flex);
+  YogaNode setFlex(float flex);
 
-  void setFlexBasisAuto();
+  YogaNode setFlexBasisAuto();
 
-  void setFlexBasisPercent(float percent);
+  YogaNode setFlexBasisPercent(float percent);
 
-  void setFlexBasis(float flexBasis);
+  YogaNode setFlexBasis(float flexBasis);
 
-  void setFlexDirection(YogaFlexDirection direction);
+  YogaNode setFlexDirection(YogaFlexDirection direction);
 
-  void setFlexGrow(float flexGrow);
+  YogaNode setFlexGrow(float flexGrow);
 
-  void setFlexShrink(float flexShrink);
+  YogaNode setFlexShrink(float flexShrink);
 
   /* Other properties */
 
-  void setJustifyContent(YogaJustify justifyContent);
+  YogaNode setJustifyContent(YogaJustify justifyContent);
 
-  void setDirection(YogaDirection direction);
+  YogaNode setDirection(YogaDirection direction);
 
-  void setBorder(YogaEdge edge, float value);
+  YogaNode setBorder(YogaEdge edge, float value);
 
-  void setWrap(YogaWrap wrap);
+  YogaNode setWrap(YogaWrap wrap);
 
-  void setAspectRatio(float aspectRatio);
+  YogaNode setAspectRatio(float aspectRatio);
 
-  void setIsReferenceBaseline(boolean isReferenceBaseline);
+  YogaNode setIsReferenceBaseline(boolean isReferenceBaseline);
 
   void setMeasureFunction(YogaMeasureFunction measureFunction);
 
-  void setBaselineFunction(YogaBaselineFunction yogaBaselineFunction);
+  YogaNode setBaselineFunction(YogaBaselineFunction yogaBaselineFunction);
 
   /* Getters */
 

--- a/src/test/java/dev/lyze/flexbox/FlexBoxTest.java
+++ b/src/test/java/dev/lyze/flexbox/FlexBoxTest.java
@@ -48,8 +48,7 @@ public class FlexBoxTest extends ApplicationAdapter {
 			VisLabel label = new VisLabel(Integer.toString(i));
 			label.setAlignment(Align.center);
 			YogaNode node = flexBox.add(label);
-			node.setWidth(100);
-			node.setHeight(100);
+			node.setWidth(100).setHeight(100);
 		}
 	}
 

--- a/src/test/java/dev/lyze/flexbox/FlexBoxTest.java
+++ b/src/test/java/dev/lyze/flexbox/FlexBoxTest.java
@@ -40,15 +40,15 @@ public class FlexBoxTest extends ApplicationAdapter {
 
 		flexBox = new FlexBox();
 		flexBox.setFillParent(true);
-		flexBox.getRoot().setFlexDirection(YogaFlexDirection.ROW);
-		flexBox.getRoot().setWrap(YogaWrap.WRAP);
+		flexBox.getRoot().setFlexDirection(YogaFlexDirection.ROW)
+				.setWrap(YogaWrap.WRAP);
 		stage.addActor(flexBox);
 
 		for (int i = 1; i < 4; i++) {
 			VisLabel label = new VisLabel(Integer.toString(i));
 			label.setAlignment(Align.center);
 			YogaNode node = flexBox.add(label);
-			node.setWidth(100).setHeight(100);
+			node.setSize(100);
 		}
 	}
 


### PR DESCRIPTION
A builder pattern makes it easier and cleaner to modify the properties of a node:

```java
node.setFlexDirection(YogaFlexDirection.ROW)
        .setWrap(YogaWrap.WRAP)
        .setWidth(100);
```

It removes a lot of unnecessarily verbose code. This is something libGDX users will be familiar with using classes like Table.

Speaking of familiarity, I added some convenience classes that combine width and height calls into one. For example ```node.setWidth(100).setHeight(100);``` becomes ```node.setSize(100);```

Thanks for your consideration.