### PR TITLE
Allow adding null actors to FlexBox.

### DIFF
--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -76,9 +76,7 @@ public class FlexBox extends WidgetGroup {
      * @return The node associated with the actor. Change the properties of the node to modify the FlexBox layout.
      */
     public YogaNode add() {
-        YogaNode node = YogaNodeFactory.create(config);
-        root.addChildAt(node, root.getChildCount());
-        return node;
+        return addAt(null, root.getChildCount());
     }
     
     /**
@@ -120,6 +118,11 @@ public class FlexBox extends WidgetGroup {
     public YogaNode addAsChild(YogaNode parent, Actor actor, int i) {
         YogaNode node = YogaNodeFactory.create(config);
 
+        if (actor == null) {
+            parent.addChildAt(node, i);
+            return node;
+        }
+        
         if (actor instanceof Layout) {
             Layout layout = (Layout) actor;
 

--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -72,6 +72,16 @@ public class FlexBox extends WidgetGroup {
     }
     
     /**
+     * Adds an empty node to the end of the root elements list. This node can be used to nest children with {@link #addAsChild(YogaNode, Actor)}.
+     * @return The node associated with the actor. Change the properties of the node to modify the FlexBox layout.
+     */
+    public YogaNode add() {
+        YogaNode node = YogaNodeFactory.create(config);
+        root.addChildAt(node, root.getChildCount());
+        return node;
+    }
+    
+    /**
      * Adds an actor to the end of the root elements list.
      * @param actor The {@link Actor Scene2D Actor} to be added to the list.
      * @return The node associated with the actor. Change the properties of the node to modify the FlexBox layout.


### PR DESCRIPTION
To create complex layouts, a user may need to nest children into a node. The clearest way to achieve this is by adding an empty node and then adding actors to that. This PR makes that process easier and without needing to know the internals of the FlexBox class.