### PR TITLE
Fix nested nodes

### DIFF
--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -67,7 +67,16 @@ public class FlexBox extends WidgetGroup {
         for (YogaActor yogaActor : nodes) {
             YogaNode node = yogaActor.getNode();
             Actor actor = yogaActor.getActor();
-            actor.setBounds(node.getLayoutX(), getHeight() - node.getLayoutY() - node.getLayoutHeight(), node.getLayoutWidth(), node.getLayoutHeight());
+            
+            float x = node.getLayoutX();
+            float y = node.getLayoutY();
+            YogaNode parent = node.getOwner();
+            while (parent != null) {
+                x += parent.getLayoutX();
+                y += parent.getLayoutY();
+                parent = parent.getOwner();
+            }
+            actor.setBounds(x, getHeight() - y - node.getLayoutHeight(), node.getLayoutWidth(), node.getLayoutHeight());
         }
     }
     

--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -98,6 +98,16 @@ public class FlexBox extends WidgetGroup {
     }
     
     /**
+     * Adds an empty node to the specified position of the root elements list. This node can be used to nest children
+     * with {@link #addAsChild(YogaNode, Actor)}.
+     * @param i The position to place the actor.
+     * @return The node associated with the actor. Change the properties of the node to modify the FlexBox layout.
+     */
+    public YogaNode addAt(int i) {
+        return addAsChild(root, null, i);
+    }
+    
+    /**
      * Adds an actor to the specified position in the root elements list.
      * @param actor The {@link Actor Scene2D Actor} to be added to the list.
      * @param i The position to place the actor.
@@ -108,6 +118,16 @@ public class FlexBox extends WidgetGroup {
     }
     
     /**
+     * Adds an empty node as a child to the specified node at the end of the elements list. This node can be used to
+     * nest children with {@link #addAsChild(YogaNode, Actor)}.
+     * @param parent The parent node that the actor will be added as a child to.
+     * @return The node associated with the actor. Change the properties of the node to modify the FlexBox layout.
+     */
+    public YogaNode addAsChild(YogaNode parent) {
+        return addAsChild(parent, null, parent.getChildCount());
+    }
+    
+    /**
      * Adds an actor as a child to the specified node at the end of the elements list.
      * @param parent The parent node that the actor will be added as a child to.
      * @param actor The {@link Actor Scene2D Actor} to be added.
@@ -115,6 +135,17 @@ public class FlexBox extends WidgetGroup {
      */
     public YogaNode addAsChild(YogaNode parent, Actor actor) {
         return addAsChild(parent, actor, parent.getChildCount());
+    }
+    
+    /**
+     * Adds an empty node as a child to the specified node to the specified position of the elements list. This node can
+     * be used to nest children with {@link #addAsChild(YogaNode, Actor)}.
+     * @param parent The parent node that the actor will be added as a child to.
+     * @param i The position to place the actor.
+     * @return The node associated with the actor. Change the properties of the node to modify the FlexBox layout.
+     */
+    public YogaNode addAsChild(YogaNode parent, int i) {
+        return addAsChild(parent, null, i);
     }
     
     /**

--- a/src/test/java/dev/lyze/flexbox/FlexBoxNestedTest.java
+++ b/src/test/java/dev/lyze/flexbox/FlexBoxNestedTest.java
@@ -1,0 +1,107 @@
+package dev.lyze.flexbox;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Buttons;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.ScreenUtils;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.kotcrab.vis.ui.VisUI;
+import com.kotcrab.vis.ui.widget.VisLabel;
+import io.github.orioncraftmc.meditate.YogaNode;
+import io.github.orioncraftmc.meditate.enums.YogaFlexDirection;
+import io.github.orioncraftmc.meditate.enums.YogaWrap;
+
+/**
+ * This test demonstrates the use of FlexBox directly in a {@link Stage Stage}. This emulates the layout of the
+ * <a href="https://yogalayout.com/playground/">Yoga Playground</a> Press LEFT CLICK to add a new element. Press RIGHT
+ * CLICK to remove an element.
+ */
+public class FlexBoxNestedTest extends ApplicationAdapter {
+	private Stage stage;
+	private FlexBox flexBox;
+	
+	public static void main(String[] args) {
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setWindowedMode(500, 500);
+		new Lwjgl3Application(new FlexBoxNestedTest(), config);
+	}
+	
+	@Override
+	public void create() {
+		VisUI.load();
+
+		stage = new Stage(new ScreenViewport());
+		stage.setDebugAll(true);
+
+		flexBox = new FlexBox();
+		flexBox.setFillParent(true);
+		flexBox.getRoot().setFlexDirection(YogaFlexDirection.ROW)
+				.setWrap(YogaWrap.WRAP);
+		stage.addActor(flexBox);
+
+		YogaNode parentNode = flexBox.add().setFlexDirection(YogaFlexDirection.COLUMN).setFlexGrow(1);
+		VisLabel testlabel = new VisLabel("test1");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		testlabel = new VisLabel("test2");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		parentNode = flexBox.add().setFlexDirection(YogaFlexDirection.COLUMN).setFlexGrow(1);
+		testlabel = new VisLabel("test3");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		testlabel = new VisLabel("test4");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		parentNode = flexBox.add().setFlexDirection(YogaFlexDirection.COLUMN).setFlexGrow(1);
+		testlabel = new VisLabel("test4");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		parentNode = flexBox.addAsChild(parentNode, null).setFlexDirection(YogaFlexDirection.ROW);
+		testlabel = new VisLabel("test5");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		testlabel = new VisLabel("test6");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+	}
+
+	@Override
+	public void render() {
+		ScreenUtils.clear(Color.BLACK);
+
+		stage.act();
+		stage.draw();
+		
+		if (Gdx.input.isButtonJustPressed(Buttons.LEFT)) {
+			VisLabel label = new VisLabel(Integer.toString(flexBox.getChildren().size + 1));
+			label.setAlignment(Align.center);
+			YogaNode node = flexBox.add(label);
+			node.setWidth(100);
+			node.setHeight(100);
+		}
+		
+		if (Gdx.input.isButtonJustPressed(Buttons.RIGHT)) {
+			if (flexBox.getChildren().size > 0) {
+				flexBox.remove(flexBox.getRoot().getChildAt(flexBox.getChildren().size - 1));
+			}
+		}
+	}
+
+	@Override
+	public void resize(int width, int height) {
+		stage.getViewport().update(width, height, true);
+		flexBox.layout();
+	}
+}

--- a/src/test/java/dev/lyze/flexbox/FlexBoxNestedTest.java
+++ b/src/test/java/dev/lyze/flexbox/FlexBoxNestedTest.java
@@ -83,20 +83,6 @@ public class FlexBoxNestedTest extends ApplicationAdapter {
 
 		stage.act();
 		stage.draw();
-		
-		if (Gdx.input.isButtonJustPressed(Buttons.LEFT)) {
-			VisLabel label = new VisLabel(Integer.toString(flexBox.getChildren().size + 1));
-			label.setAlignment(Align.center);
-			YogaNode node = flexBox.add(label);
-			node.setWidth(100);
-			node.setHeight(100);
-		}
-		
-		if (Gdx.input.isButtonJustPressed(Buttons.RIGHT)) {
-			if (flexBox.getChildren().size > 0) {
-				flexBox.remove(flexBox.getRoot().getChildAt(flexBox.getChildren().size - 1));
-			}
-		}
 	}
 
 	@Override

--- a/src/test/java/dev/lyze/flexbox/FlexBoxNestedTest.java
+++ b/src/test/java/dev/lyze/flexbox/FlexBoxNestedTest.java
@@ -67,7 +67,7 @@ public class FlexBoxNestedTest extends ApplicationAdapter {
 		testlabel.setAlignment(Align.center);
 		flexBox.addAsChild(parentNode, testlabel);
 		
-		parentNode = flexBox.addAsChild(parentNode, null).setFlexDirection(YogaFlexDirection.ROW);
+		parentNode = flexBox.addAsChild(parentNode).setFlexDirection(YogaFlexDirection.ROW);
 		testlabel = new VisLabel("test5");
 		testlabel.setAlignment(Align.center);
 		flexBox.addAsChild(parentNode, testlabel);


### PR DESCRIPTION
I identified an issue with the layout of actors that are placed in nested nodes. Apparently, it did not account for the coordinates of the parent nodes. Apparently my previous testing happened to accidentally look like it was working correctly. See the new test to compare to the previous behavior.
I also added some more helper methods to add empty nodes to existing nodes.