### PR TITLE
Fix wrapped labels and unable to change values.

### DIFF
--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -53,6 +53,16 @@ public class FlexBox extends WidgetGroup {
     public void layout() {
         super.layout();
     
+        for (YogaActor yogaActor : nodes) {
+            YogaNode yogaNode  = yogaActor.node;
+            Actor actor = yogaActor.actor;
+            if (actor instanceof Layout) {
+                Layout layout = (Layout) actor;
+                yogaNode.setMinWidth(layout.getMinWidth());
+                yogaNode.setMinHeight(layout.getMinHeight());
+            }
+        }
+        
         //update the bounds of the FlexBox
         if (prefSizeInvalid) calcPrefSize();
         if (prefWidth != lastPrefWidth || prefHeight != lastPrefHeight) {

--- a/src/main/java/io/github/orioncraftmc/meditate/internal/detail/CompactValue.java
+++ b/src/main/java/io/github/orioncraftmc/meditate/internal/detail/CompactValue.java
@@ -77,7 +77,7 @@ public class CompactValue //Type originates from: CompactValue.h
 
     public static boolean equalsTo( CompactValue a,  CompactValue b) //Method definition originates from: CompactValue.h
     {
-        return a.payload_.unit.equals(b.payload_.unit);
+        return a.payload_.unit.equals(b.payload_.unit) && a.payload_.value == b.payload_.value;
     }
 
     public YGValue convertToYgValue() {

--- a/src/test/java/dev/lyze/flexbox/FlexBoxWrappedLabelTest.java
+++ b/src/test/java/dev/lyze/flexbox/FlexBoxWrappedLabelTest.java
@@ -1,0 +1,76 @@
+package dev.lyze.flexbox;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.ScreenUtils;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.kotcrab.vis.ui.VisUI;
+import com.kotcrab.vis.ui.widget.VisLabel;
+import io.github.orioncraftmc.meditate.YogaNode;
+import io.github.orioncraftmc.meditate.enums.YogaFlexDirection;
+import io.github.orioncraftmc.meditate.enums.YogaWrap;
+
+/**
+ * This test demonstrates the use of FlexBox directly in a {@link Stage Stage}. This emulates the layout of the
+ * <a href="https://yogalayout.com/playground/">Yoga Playground</a> Press LEFT CLICK to add a new element. Press RIGHT
+ * CLICK to remove an element.
+ */
+public class FlexBoxWrappedLabelTest extends ApplicationAdapter {
+	private Stage stage;
+	private FlexBox flexBox;
+	private final String LONG_TEXT = "Hello. This is a demonstration of long text that should automatically be wrapped" +
+			" to the next line. It is absurd to expect otherwise. And yet there is always a chance for this opposing" +
+			"viewpoint. Even as infinitesimal as it may be, it must be tested. Thus, we shall begin...";
+	
+	public static void main(String[] args) {
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setWindowedMode(500, 500);
+		new Lwjgl3Application(new FlexBoxWrappedLabelTest(), config);
+	}
+	
+	@Override
+	public void create() {
+		VisUI.load();
+
+		stage = new Stage(new ScreenViewport());
+		stage.setDebugAll(true);
+
+		flexBox = new FlexBox();
+		flexBox.setFillParent(true);
+		flexBox.getRoot().setFlexDirection(YogaFlexDirection.ROW)
+				.setWrap(YogaWrap.WRAP);
+		stage.addActor(flexBox);
+
+		YogaNode parentNode = flexBox.add().setFlexDirection(YogaFlexDirection.COLUMN).setFlexGrow(1);
+		VisLabel testlabel = new VisLabel("test1");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		testlabel = new VisLabel(LONG_TEXT);
+		testlabel.setWrap(true);
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+		
+		testlabel = new VisLabel("test3");
+		testlabel.setAlignment(Align.center);
+		flexBox.addAsChild(parentNode, testlabel);
+	}
+
+	@Override
+	public void render() {
+		ScreenUtils.clear(Color.BLACK);
+
+		stage.act();
+		stage.draw();
+	}
+
+	@Override
+	public void resize(int width, int height) {
+		stage.getViewport().update(width, height, true);
+		flexBox.layout();
+	}
+}


### PR DESCRIPTION
I noticed that wrapped labels were broken when implemented inside of a FlexBox. This led me into a rabbit hole that also revealed a bug with values being unable to be changed after they are set with an initial value. This is due to the fact that the C++ source for CompactValue is composed of type and actual value packed into int and that is compared, while in java side only type is. Thanks goes to Evilentity for the explanation.