### PR TITLE
Add hack to honor user set changes to minWidth/minHeight.

### DIFF
--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -5,10 +5,8 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup;
 import com.badlogic.gdx.scenes.scene2d.utils.Layout;
 import com.badlogic.gdx.utils.Array;
-import io.github.orioncraftmc.meditate.YogaConfig;
-import io.github.orioncraftmc.meditate.YogaConfigFactory;
-import io.github.orioncraftmc.meditate.YogaNode;
-import io.github.orioncraftmc.meditate.YogaNodeFactory;
+import io.github.orioncraftmc.meditate.*;
+import io.github.orioncraftmc.meditate.enums.YogaUnit;
 
 /**
  * A Scene2D widget that implements Yoga Layout by Facebook. FlexBox is a clean and powerful alternative to group
@@ -58,8 +56,15 @@ public class FlexBox extends WidgetGroup {
             Actor actor = yogaActor.actor;
             if (actor instanceof Layout) {
                 Layout layout = (Layout) actor;
-                yogaNode.setMinWidth(layout.getMinWidth());
-                yogaNode.setMinHeight(layout.getMinHeight());
+
+                if (!((YogaNodeWrapper) yogaNode).minWidthManuallySet) {
+                    yogaNode.setMinWidth(layout.getMinWidth());
+                    ((YogaNodeWrapper)yogaNode).minWidthManuallySet = false;
+                }
+                if (!((YogaNodeWrapper) yogaNode).minHeightManuallySet) {
+                    yogaNode.setMinHeight(layout.getMinHeight());
+                    ((YogaNodeWrapper)yogaNode).minHeightManuallySet = false;
+                }
             }
         }
         
@@ -178,6 +183,8 @@ public class FlexBox extends WidgetGroup {
 
             node.setMinWidth(layout.getMinWidth());
             node.setMinHeight(layout.getMinHeight());
+            ((YogaNodeWrapper)node).minWidthManuallySet = false;
+            ((YogaNodeWrapper)node).minHeightManuallySet = false;
         } else {
             node.setWidth(actor.getWidth());
             node.setHeight(actor.getHeight());

--- a/src/main/java/io/github/orioncraftmc/meditate/YogaNodeWrapper.java
+++ b/src/main/java/io/github/orioncraftmc/meditate/YogaNodeWrapper.java
@@ -46,6 +46,9 @@ public class YogaNodeWrapper extends YogaNode {
     private Object mData;
 
     private int mLayoutDirection = 0;
+    
+    public boolean minWidthManuallySet;
+    public boolean minHeightManuallySet;
 
     private YogaNodeWrapper(YGNode nativePointer) {
         mNativePointer = nativePointer;
@@ -504,11 +507,13 @@ public class YogaNodeWrapper extends YogaNode {
     }
 
     public YogaNode setMinWidth(float minWidth) {
+        minWidthManuallySet = true;
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinWidth(mNativePointer, minWidth);
         return this;
     }
 
     public YogaNode setMinWidthPercent(float percent) {
+        minWidthManuallySet = true;
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinWidthPercent(mNativePointer, percent);
         return this;
     }
@@ -518,11 +523,13 @@ public class YogaNodeWrapper extends YogaNode {
     }
 
     public YogaNode setMinHeight(float minHeight) {
+        minHeightManuallySet = true;
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinHeight(mNativePointer, minHeight);
         return this;
     }
 
     public YogaNode setMinHeightPercent(float percent) {
+        minHeightManuallySet = true;
         io.github.orioncraftmc.meditate.internal.GlobalMembers.YGNodeStyleSetMinHeightPercent(mNativePointer, percent);
         return this;
     }


### PR DESCRIPTION
I made an omission in my last PR which overrode any custom set minWidth or minHeight by the user. This dirty hack honors any custom minWidth or minHeight set by the user, otherwise it defaults to the minWidth and minHeight of the Actor