### PR TITLE
Fix incorrect layout positioning.

### DIFF
--- a/src/main/java/dev/lyze/flexbox/FlexBox.java
+++ b/src/main/java/dev/lyze/flexbox/FlexBox.java
@@ -80,7 +80,6 @@ public class FlexBox extends WidgetGroup {
             lastPrefHeight = prefHeight;
             invalidateHierarchy();
         }
-        setBounds(0, 0, getWidth(), getHeight());
     
         //update the bounds of the children
         root.calculateLayout(getWidth(), getHeight());


### PR DESCRIPTION
This resolves the issue of FlexBox setting the layout position to 0,0. This overrides the position if you're manually positioning the FlexBox in a Stage or any widget. I'm not sure why that line was there in the first place ¯\_(ツ)_/¯